### PR TITLE
Fix Team numbering when deleting a team

### DIFF
--- a/src/gui_tools/GuiUtil/TeamSelector.cpp
+++ b/src/gui_tools/GuiUtil/TeamSelector.cpp
@@ -249,6 +249,14 @@ void MusicQuiz::TeamSelector::addTeam()
 	}
 }
 
+void MusicQuiz::TeamSelector::setTeamNumbers()
+{
+	for ( int i = 0; i < _teamTable->rowCount(); ++i ) {
+		const QString teamNumber = " Team " + QString::number(i + 1);
+		_teamTable->item(i, 0)->setData(Qt::DisplayRole, teamNumber);
+	}
+}
+
 void MusicQuiz::TeamSelector::removeTeam()
 {
 	/** Sanity Check */
@@ -283,8 +291,8 @@ void MusicQuiz::TeamSelector::removeTeam()
 	_teamTable->removeRow(selectedRow);
 
 	/** Delete button */
-	button = nullptr;
 	delete button;
+	button = nullptr;
 
 	/** Enable Line Edit and slider if count is below the maximum number of teams */
 	if ( !_teamNameLineEdit->isEnabled() ) {
@@ -295,6 +303,7 @@ void MusicQuiz::TeamSelector::removeTeam()
 		_hueSlider->setEnabled(true);
 		_hueSlider->setValue(_hueSlider->minimum());
 	}
+	setTeamNumbers();
 }
 
 void MusicQuiz::TeamSelector::teamColorChanged(QColor color)

--- a/src/gui_tools/GuiUtil/TeamSelector.hpp
+++ b/src/gui_tools/GuiUtil/TeamSelector.hpp
@@ -101,6 +101,11 @@ namespace MusicQuiz {
 		 */
 		void createLayout();
 
+		/**
+		 * @brief Sets the team number of all teams
+		 */
+		void setTeamNumbers();
+
 		/** Variables */
 		bool _quizClosed = false;
 		const size_t _maximumsNumberOfTeams = 6;


### PR DESCRIPTION
Fixes #2 
When deleting a team, the team numbers was not recalculated.
This caused multiple teams to be created with the same teamnumber if
new teams was added after a deletion.

When removing a team, always recompute the string for the teamnumber