### PR TITLE
Fix audio and video playback on Linux

### DIFF
--- a/src/media/AudioPlayer.hpp
+++ b/src/media/AudioPlayer.hpp
@@ -50,16 +50,9 @@ namespace media {
 		 * @brief Plays a video.
 		 *
 		 * @param[in] audioFile The name of the audio file to play.
+		 * @param[in] startTime The time at which to start playing the audio file from.
 		 */
-		void play(const QString& audioFile);
-
-		/**
-		 * @brief Plays a video.
-		 *
-		 * @param[in] audioFile The name of the audio file to play.
-		 * @param[in] startTime The time at which to start playing the video file from.
-		 */
-		void play(const QString& audioFile, size_t startTime);
+		void play(const QString& audioFile, size_t startTime = 0);
 
 		/**
 		 * @brief Pauses the audio that is currently playing.
@@ -75,6 +68,13 @@ namespace media {
 		 * @brief Stops the audio.
 		 */
 		void stop();
+
+	private slots:
+		/**
+		 * @brief Handles mediastatus changes
+		 */
+		void handleMediaStatus(QMediaPlayer::MediaStatus status);
+
 	protected:
 
 		/** Variables */

--- a/src/media/VideoPlayer.hpp
+++ b/src/media/VideoPlayer.hpp
@@ -51,18 +51,10 @@ namespace media {
 		 * @brief Plays a video.
 		 *
 		 * @param[in] videoFile The name of the video file to play.
-		 * @param[in] muted True if the audio should be muted.
-		 */
-		void play(const QString& videoFile, bool muted = false);
-
-		/**
-		 * @brief Plays a video.
-		 *
-		 * @param[in] videoFile The name of the video file to play.
 		 * @param[in] startTime The time at which to start playing the video file from.
 		 * @param[in] muted True if the audio should be muted.
 		 */
-		void play(const QString& videoFile, size_t startTime, bool muted = false);
+		void play(const QString& videoFile, size_t startTime = 0, bool muted = false);
 
 		/**
 		 * @brief Pauses the video that is currently playing.
@@ -92,6 +84,13 @@ namespace media {
 		 * @param[in] mouseEventCallback The callback function.
 		 */
 		void setMouseEventCallbackFunction(const std::function< void(QMouseEvent*) > mouseEventCallback);
+
+	private slots:
+		/**
+		 * @brief Handles mediastatus changes
+		 */
+		void handleMediaStatus(QMediaPlayer::MediaStatus status);
+
 	protected:
 		/**
 		 * @brief Override the mouse release event.


### PR DESCRIPTION
Audio and video wouldn't play when loaded under linux, untill they where paused and then resumed.
Don't start playback immedialy after loading, but wait for the mediaStatusChanged
to be fired with a status indicating that the file was loaded. Then
start playback in the callback function

- [ ] Please Test that playback still works correctly on Windows before merge